### PR TITLE
Prepend class to assignments and subjects

### DIFF
--- a/frontend/src/components/SubjectClassAssignment.tsx
+++ b/frontend/src/components/SubjectClassAssignment.tsx
@@ -151,7 +151,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
         <Box display="flex" alignItems="center" gap={1}>
           <Assignment color="primary" />
           <Typography variant="h6">
-            Subject & Class Assignment for {teacherName}
+            class Subject & Class Assignment for {teacherName}
           </Typography>
         </Box>
       </DialogTitle>
@@ -161,7 +161,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
           {/* Current Assignments */}
           <Grid item xs={12}>
             <Typography variant="h6" gutterBottom>
-              Current Assignments
+              class Current Assignments
             </Typography>
             {assignments.length === 0 ? (
               <Alert severity="info">
@@ -214,7 +214,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
           {/* Add New Assignment */}
           <Grid item xs={12}>
             <Typography variant="h6" gutterBottom>
-              Add New Assignment
+              class Add New Assignment
             </Typography>
             
             {error && (
@@ -283,7 +283,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
                   onClick={handleAddAssignment}
                   disabled={!selectedClass || !selectedSubjects.trim()}
                 >
-                  Add Assignment
+                  class Add Assignment
                 </Button>
               </Grid>
             </Grid>
@@ -317,7 +317,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
           onClick={handleSave}
           startIcon={<CheckCircle />}
         >
-          Save Assignments
+          class Save Assignments
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/pages/Classes.tsx
+++ b/frontend/src/pages/Classes.tsx
@@ -64,7 +64,7 @@ const Classes: React.FC = () => {
 
                 <Box sx={{ mb: 2 }}>
                   <Typography variant="subtitle2" color="text.secondary">
-                    Subjects:
+                    class Subjects:
                   </Typography>
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
                     {cls.subjects.map((subject) => (

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -78,7 +78,7 @@ const Dashboard: React.FC = () => {
       case 'teacher':
         return [
           { text: 'Mark Attendance', action: '/attendance' },
-          { text: 'Assign Homework', action: '/homework' },
+          { text: 'class Assign Homework', action: '/homework' },
           { text: 'Create Test', action: '/tests' },
           { text: 'View Results', action: '/results' },
         ];

--- a/frontend/src/pages/Homework.tsx
+++ b/frontend/src/pages/Homework.tsx
@@ -61,7 +61,7 @@ const Homework: React.FC = () => {
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Typography variant="h4">Homework Management</Typography>
         <Button variant="contained" startIcon={<Add />}>
-          Assign Homework
+          class Assign Homework
         </Button>
       </Box>
 

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -104,7 +104,7 @@ const Results: React.FC = () => {
 
                 <Box>
                   <Typography variant="subtitle2" gutterBottom>
-                    Subject-wise Performance:
+                    class Subject-wise Performance:
                   </Typography>
                   {result.subjects.map((subject, index) => (
                     <Box key={index} sx={{ mb: 1 }}>

--- a/frontend/src/pages/TeacherManagement.tsx
+++ b/frontend/src/pages/TeacherManagement.tsx
@@ -846,7 +846,7 @@ const TeacherManagement: React.FC = () => {
                     <TableRow>
                       <TableCell>Teacher</TableCell>
                       <TableCell>Designation</TableCell>
-                      <TableCell>Subjects</TableCell>
+                      <TableCell>class Subjects</TableCell>
                       <TableCell>Classes</TableCell>
                       <TableCell>Status</TableCell>
                       <TableCell>Last Login</TableCell>
@@ -957,7 +957,7 @@ const TeacherManagement: React.FC = () => {
                                 <LockReset />
                               </IconButton>
                             </Tooltip>
-                            <Tooltip title="Assign Classes & Subjects">
+                            <Tooltip title="class Assign Classes & Subjects">
                               <IconButton size="small" onClick={() => handleOpenSubjectAssignmentDialog(teacher)}>
                                 <Assignment />
                               </IconButton>
@@ -1061,7 +1061,7 @@ const TeacherManagement: React.FC = () => {
               <Grid item xs={12}>
                 <Alert severity="info">
                   <Typography variant="body2">
-                    <strong>Note:</strong> Subject assignments are now managed through the "Assign Subjects" button in the teacher list. 
+                    <strong>Note:</strong> class Subject assignments are now managed through the "class Assign Subjects" button in the teacher list. 
                     This allows you to assign specific subjects to specific classes and sections.
                   </Typography>
                 </Alert>
@@ -1250,11 +1250,11 @@ const TeacherManagement: React.FC = () => {
       {/* Subject Assignment Dialog */}
       {openSubjectAssignmentDialog && selectedTeacher && (
         <Dialog open={openSubjectAssignmentDialog} onClose={() => setOpenSubjectAssignmentDialog(false)} maxWidth="sm" fullWidth>
-          <DialogTitle>Assign Classes & Subjects - {selectedTeacher.name}</DialogTitle>
+          <DialogTitle>class Assign Classes & Subjects - {selectedTeacher.name}</DialogTitle>
           <DialogContent>
             <Box sx={{ mb: 2 }}>
               <Alert severity="info">
-                Assign classes and subjects to this teacher. You can edit or delete existing assignments, or add new ones below.
+                class Assign classes and subjects to this teacher. You can edit or delete existing assignments, or add new ones below.
               </Alert>
             </Box>
             {/* List of current assignments */}
@@ -1262,8 +1262,8 @@ const TeacherManagement: React.FC = () => {
               <Box sx={{ mb: 2 }}>
                 {assignments.map((a, idx) => (
                   <Box key={idx} sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-                    <Typography sx={{ minWidth: 150 }}>{a.className} - Section {a.section}</Typography>
-                    <Typography sx={{ flex: 1, ml: 2 }}>{a.subjects.join(', ')}</Typography>
+                    <Typography sx={{ minWidth: 150 }}>class {a.className} - Section {a.section}</Typography>
+                    <Typography sx={{ flex: 1, ml: 2 }}>class {a.subjects.join(', ')}</Typography>
                     <Button size="small" color="primary" onClick={() => handleEditAssignment(idx)}>Edit</Button>
                     <Button size="small" color="error" onClick={() => handleDeleteAssignment(idx)}>Delete</Button>
                   </Box>
@@ -1324,7 +1324,7 @@ const TeacherManagement: React.FC = () => {
                   onClick={handleAddOrUpdateAssignment}
                   sx={{ mt: 1 }}
                 >
-                  {assignmentForm.editingIndex === -1 ? 'Add Assignment' : 'Update Assignment'}
+                  {assignmentForm.editingIndex === -1 ? 'class Add Assignment' : 'class Update Assignment'}
                 </Button>
               </Grid>
             </Grid>
@@ -1337,7 +1337,7 @@ const TeacherManagement: React.FC = () => {
                 await handleSaveSubjectAssignments(assignments);
               }}
             >
-              Save All Assignments
+              class Save All Assignments
             </Button>
           </DialogActions>
         </Dialog>


### PR DESCRIPTION
Add "class" text prefix to various UI elements related to assignments and subjects.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba61eed3-340d-4ff2-a23f-47a12dabe8c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba61eed3-340d-4ff2-a23f-47a12dabe8c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

