### PR TITLE
Prepend class to assignments and subjects

### DIFF
--- a/frontend/src/components/SubjectClassAssignment.tsx
+++ b/frontend/src/components/SubjectClassAssignment.tsx
@@ -151,7 +151,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
         <Box display="flex" alignItems="center" gap={1}>
           <Assignment color="primary" />
           <Typography variant="h6">
-            Subject & Class Assignment for {teacherName}
+            class Subject & Class Assignment for {teacherName}
           </Typography>
         </Box>
       </DialogTitle>
@@ -161,7 +161,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
           {/* Current Assignments */}
           <Grid item xs={12}>
             <Typography variant="h6" gutterBottom>
-              Current Assignments
+              class Current Assignments
             </Typography>
             {assignments.length === 0 ? (
               <Alert severity="info">
@@ -184,7 +184,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
                             {assignment.subjects.map((subject, index) => (
                               <Chip
                                 key={index}
-                                label={subject}
+                                label={`class ${subject}`}
                                 size="small"
                                 color="secondary"
                                 sx={{ mr: 0.5, mb: 0.5 }}
@@ -214,7 +214,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
           {/* Add New Assignment */}
           <Grid item xs={12}>
             <Typography variant="h6" gutterBottom>
-              Add New Assignment
+              class Add New Assignment
             </Typography>
             
             {error && (
@@ -244,7 +244,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
               <Grid item xs={12} md={6}>
                 <TextField
                   fullWidth
-                  label="Subjects (comma separated)"
+                  label="class Subjects (comma separated)"
                   value={selectedSubjects}
                   onChange={(e) => setSelectedSubjects(e.target.value)}
                   placeholder="Mathematics, Physics, English"
@@ -254,7 +254,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
 
               <Grid item xs={12}>
                 <Typography variant="body2" color="textSecondary" gutterBottom>
-                  Common Subjects:
+                  class Common Subjects:
                 </Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                   {commonSubjects.map((subject) => (
@@ -283,7 +283,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
                   onClick={handleAddAssignment}
                   disabled={!selectedClass || !selectedSubjects.trim()}
                 >
-                  Add Assignment
+                  class Add Assignment
                 </Button>
               </Grid>
             </Grid>
@@ -300,7 +300,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
                 • Total Classes Assigned: {assignments.length}
               </Typography>
               <Typography variant="body2" color="textSecondary">
-                • Total Subjects: {assignments.reduce((total, a) => total + a.subjects.length, 0)}
+                • class Total Subjects: {assignments.reduce((total, a) => total + a.subjects.length, 0)}
               </Typography>
               <Typography variant="body2" color="textSecondary">
                 • Available Classes: {getUnassignedClasses().length}
@@ -317,7 +317,7 @@ const SubjectClassAssignment: React.FC<SubjectClassAssignmentProps> = ({
           onClick={handleSave}
           startIcon={<CheckCircle />}
         >
-          Save Assignments
+          class Save Assignments
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/pages/Classes.tsx
+++ b/frontend/src/pages/Classes.tsx
@@ -64,11 +64,11 @@ const Classes: React.FC = () => {
 
                 <Box sx={{ mb: 2 }}>
                   <Typography variant="subtitle2" color="text.secondary">
-                    Subjects:
+                    class Subjects:
                   </Typography>
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
                     {cls.subjects.map((subject) => (
-                      <Chip key={subject} label={subject} size="small" variant="outlined" />
+                      <Chip key={subject} label={`class ${subject}`} size="small" variant="outlined" />
                     ))}
                   </Box>
                 </Box>

--- a/frontend/src/pages/Homework.tsx
+++ b/frontend/src/pages/Homework.tsx
@@ -77,7 +77,7 @@ const Homework: React.FC = () => {
                   <Box sx={{ flexGrow: 1 }}>
                     <Typography variant="h6">{homework.title}</Typography>
                     <Typography variant="body2" color="text.secondary">
-                      {homework.subject} - {homework.class}
+                      class {homework.subject} - {homework.class}
                     </Typography>
                   </Box>
                   {getStatusIcon(homework.status)}
@@ -124,7 +124,7 @@ const Homework: React.FC = () => {
                     size="small"
                   />
                   <Chip
-                    label={homework.subject}
+                    label={`class ${homework.subject}`}
                     variant="outlined"
                     size="small"
                   />

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -104,12 +104,12 @@ const Results: React.FC = () => {
 
                 <Box>
                   <Typography variant="subtitle2" gutterBottom>
-                    Subject-wise Performance:
+                    class Subject-wise Performance:
                   </Typography>
                   {result.subjects.map((subject, index) => (
                     <Box key={index} sx={{ mb: 1 }}>
                       <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
-                        <Typography variant="body2">{subject.name}</Typography>
+                        <Typography variant="body2">class {subject.name}</Typography>
                         <Typography variant="body2">
                           {subject.marks}/{subject.maxMarks}
                         </Typography>

--- a/frontend/src/pages/TeacherManagement.tsx
+++ b/frontend/src/pages/TeacherManagement.tsx
@@ -846,7 +846,7 @@ const TeacherManagement: React.FC = () => {
                     <TableRow>
                       <TableCell>Teacher</TableCell>
                       <TableCell>Designation</TableCell>
-                      <TableCell>Subjects</TableCell>
+                      <TableCell>class Subjects</TableCell>
                       <TableCell>Classes</TableCell>
                       <TableCell>Status</TableCell>
                       <TableCell>Last Login</TableCell>
@@ -882,7 +882,7 @@ const TeacherManagement: React.FC = () => {
                         <TableCell>
                           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                             {(teacher.subjects || []).slice(0, 2).map((subject) => (
-                              <Chip key={subject} label={subject} size="small" variant="outlined" />
+                              <Chip key={subject} label={`class ${subject}`} size="small" variant="outlined" />
                             ))}
                             {(teacher.subjects && teacher.subjects.length > 2) && (
                               <Chip label={`+${teacher.subjects.length - 2}`} size="small" />
@@ -957,7 +957,7 @@ const TeacherManagement: React.FC = () => {
                                 <LockReset />
                               </IconButton>
                             </Tooltip>
-                            <Tooltip title="Assign Classes & Subjects">
+                            <Tooltip title="class Assign Classes & Subjects">
                               <IconButton size="small" onClick={() => handleOpenSubjectAssignmentDialog(teacher)}>
                                 <Assignment />
                               </IconButton>
@@ -1061,7 +1061,7 @@ const TeacherManagement: React.FC = () => {
               <Grid item xs={12}>
                 <Alert severity="info">
                   <Typography variant="body2">
-                    <strong>Note:</strong> Subject assignments are now managed through the "Assign Subjects" button in the teacher list. 
+                    <strong>Note:</strong> class Subject assignments are now managed through the "class Assign Subjects" button in the teacher list. 
                     This allows you to assign specific subjects to specific classes and sections.
                   </Typography>
                 </Alert>
@@ -1250,7 +1250,7 @@ const TeacherManagement: React.FC = () => {
       {/* Subject Assignment Dialog */}
       {openSubjectAssignmentDialog && selectedTeacher && (
         <Dialog open={openSubjectAssignmentDialog} onClose={() => setOpenSubjectAssignmentDialog(false)} maxWidth="sm" fullWidth>
-          <DialogTitle>Assign Classes & Subjects - {selectedTeacher.name}</DialogTitle>
+          <DialogTitle>class Assign Classes & Subjects - {selectedTeacher.name}</DialogTitle>
           <DialogContent>
             <Box sx={{ mb: 2 }}>
               <Alert severity="info">
@@ -1263,7 +1263,7 @@ const TeacherManagement: React.FC = () => {
                 {assignments.map((a, idx) => (
                   <Box key={idx} sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                     <Typography sx={{ minWidth: 150 }}>{a.className} - Section {a.section}</Typography>
-                    <Typography sx={{ flex: 1, ml: 2 }}>{a.subjects.join(', ')}</Typography>
+                    <Typography sx={{ flex: 1, ml: 2 }}>class {a.subjects.join(', ')}</Typography>
                     <Button size="small" color="primary" onClick={() => handleEditAssignment(idx)}>Edit</Button>
                     <Button size="small" color="error" onClick={() => handleDeleteAssignment(idx)}>Delete</Button>
                   </Box>
@@ -1311,7 +1311,7 @@ const TeacherManagement: React.FC = () => {
               <Grid item xs={12} md={4}>
                 <TextField
                   fullWidth
-                  label="Subjects (comma separated)"
+                  label="class Subjects (comma separated)"
                   value={assignmentForm.subjectsInput}
                   onChange={e => setAssignmentForm({ ...assignmentForm, subjectsInput: e.target.value })}
                   placeholder="Mathematics, Physics, English"
@@ -1324,7 +1324,7 @@ const TeacherManagement: React.FC = () => {
                   onClick={handleAddOrUpdateAssignment}
                   sx={{ mt: 1 }}
                 >
-                  {assignmentForm.editingIndex === -1 ? 'Add Assignment' : 'Update Assignment'}
+                  {assignmentForm.editingIndex === -1 ? 'class Add Assignment' : 'class Update Assignment'}
                 </Button>
               </Grid>
             </Grid>
@@ -1337,7 +1337,7 @@ const TeacherManagement: React.FC = () => {
                 await handleSaveSubjectAssignments(assignments);
               }}
             >
-              Save All Assignments
+              class Save All Assignments
             </Button>
           </DialogActions>
         </Dialog>

--- a/frontend/src/pages/Tests.tsx
+++ b/frontend/src/pages/Tests.tsx
@@ -79,7 +79,7 @@ const Tests: React.FC = () => {
                   <Box sx={{ flexGrow: 1 }}>
                     <Typography variant="h6">{test.title}</Typography>
                     <Typography variant="body2" color="text.secondary">
-                      {test.subject} - {test.class}
+                      class {test.subject} - {test.class}
                     </Typography>
                   </Box>
                 </Box>
@@ -109,7 +109,7 @@ const Tests: React.FC = () => {
                     size="small"
                   />
                   <Chip
-                    label={test.subject}
+                    label={`class ${test.subject}`}
                     variant="outlined"
                     size="small"
                   />


### PR DESCRIPTION
Add 'class' prefix to assignment and subject related text elements in the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-2136ba2c-93ac-4956-a08a-6f830242949f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2136ba2c-93ac-4956-a08a-6f830242949f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

