### PR TITLE
Fix delete assignment teacher subject

### DIFF
--- a/frontend/src/pages/Actions.tsx
+++ b/frontend/src/pages/Actions.tsx
@@ -119,7 +119,7 @@ const Actions: React.FC = () => {
       // Send updated assignments to backend
       const res = await apiService.post<{ success: boolean; data: TeacherDetail; message: string }>(
         `/admin/teachers/${teacherDetail._id}/assign-classes`, 
-        { assignedClasses: remaining }
+        { assignedClasses: remaining, replaceAll: true }
       );
       
       if (res.data) {
@@ -277,7 +277,7 @@ const Actions: React.FC = () => {
         };
       });
 
-      const res = await apiService.post<{ success: boolean; data: TeacherDetail }>(`/admin/teachers/${teacherDetail._id}/assign-classes`, { assignedClasses: updated });
+      const res = await apiService.post<{ success: boolean; data: TeacherDetail }>(`/admin/teachers/${teacherDetail._id}/assign-classes`, { assignedClasses: updated, replaceAll: true });
       setTeacherDetail(res.data);
       setEditTarget(null);
       setEditForm(null);


### PR DESCRIPTION
Fixes broken teacher-subject assignment deletion by implementing a `replaceAll` flag.

The backend's `assignClassesToTeacher` endpoint previously only merged new assignments, meaning entries removed from the frontend list were not actually deleted. This change introduces a `replaceAll` flag, which, when true, causes the backend to completely overwrite the existing assignments with the provided list, thus enabling proper deletion and editing.

---
<a href="https://cursor.com/background-agent?bcId=bc-c81ba4c3-a1d0-495a-8320-23931c5e2258">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c81ba4c3-a1d0-495a-8320-23931c5e2258">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

