### PR TITLE
Fix duplicate student creation dialog

### DIFF
--- a/frontend/src/components/StudentRegistrationForm.tsx
+++ b/frontend/src/components/StudentRegistrationForm.tsx
@@ -49,11 +49,13 @@ interface StudentFormData {
 interface StudentRegistrationFormProps {
   onSubmit: (data: StudentFormData) => void;
   loading?: boolean;
+  inDialog?: boolean;
 }
 
 const StudentRegistrationForm: React.FC<StudentRegistrationFormProps> = ({
   onSubmit,
-  loading = false
+  loading = false,
+  inDialog = false,
 }) => {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -148,20 +150,26 @@ const StudentRegistrationForm: React.FC<StudentRegistrationFormProps> = ({
   };
 
   if (loadingClasses) {
-    return (
+    const loadingContent = (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 200 }}>
+        <CircularProgress />
+      </Box>
+    );
+    
+    return inDialog ? loadingContent : (
       <Paper elevation={3} sx={{ p: 4, maxWidth: 800, mx: 'auto' }}>
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 200 }}>
-          <CircularProgress />
-        </Box>
+        {loadingContent}
       </Paper>
     );
   }
 
-  return (
-    <Paper elevation={3} sx={{ p: 4, maxWidth: 800, mx: 'auto' }}>
-      <Typography variant="h5" gutterBottom>
-        Student Registration
-      </Typography>
+  const formContent = (
+    <>
+      {!inDialog && (
+        <Typography variant="h5" gutterBottom>
+          Student Registration
+        </Typography>
+      )}
       
       {error && (
         <Alert severity="error" sx={{ mb: 2 }}>
@@ -335,6 +343,12 @@ const StudentRegistrationForm: React.FC<StudentRegistrationFormProps> = ({
           </Button>
         </Box>
       </Box>
+    </>
+  );
+
+  return inDialog ? formContent : (
+    <Paper elevation={3} sx={{ p: 4, maxWidth: 800, mx: 'auto' }}>
+      {formContent}
     </Paper>
   );
 };

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -569,6 +569,7 @@ const Students: React.FC = () => {
           <StudentRegistrationForm
             onSubmit={handleRegisterStudent}
             loading={fetchingStudents}
+            inDialog={true}
           />
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
Fixes student creation dialog appearing double by conditionally removing redundant Paper wrapper when used in a dialog.

---
<a href="https://cursor.com/background-agent?bcId=bc-d57e651d-5d4b-4036-bae8-8d9b6f36a6ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d57e651d-5d4b-4036-bae8-8d9b6f36a6ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

