### PR TITLE
Remove process promotion button from session

### DIFF
--- a/frontend/src/pages/Sessions.tsx
+++ b/frontend/src/pages/Sessions.tsx
@@ -630,15 +630,6 @@ const Sessions: React.FC = () => {
                       <Button
                         size="small"
                         variant="outlined"
-                        startIcon={<TrendingUpIcon />}
-                        onClick={() => handleProcessPromotions(session)}
-                        disabled={!['admin', 'principal'].includes(user?.role || '')}
-                      >
-                        Process Promotions
-                      </Button>
-                      <Button
-                        size="small"
-                        variant="outlined"
                         startIcon={<ArchiveIcon />}
                         onClick={() => handleArchiveSession(session)}
                         disabled={!['admin', 'principal'].includes(user?.role || '')}


### PR DESCRIPTION
Remove the "Process Promotions" button from the sessions page.

---
<a href="https://cursor.com/background-agent?bcId=bc-b46b6b71-c69f-4143-b6d0-ae455ba618da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b46b6b71-c69f-4143-b6d0-ae455ba618da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

