### PR TITLE
Remove process promotion button from session

### DIFF
--- a/frontend/src/pages/Sessions.tsx
+++ b/frontend/src/pages/Sessions.tsx
@@ -627,15 +627,17 @@ const Sessions: React.FC = () => {
                   {/* Session Management Options */}
                   {session.status === 'active' && (
                     <>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        startIcon={<TrendingUpIcon />}
-                        onClick={() => handleProcessPromotions(session)}
-                        disabled={!['admin', 'principal'].includes(user?.role || '')}
-                      >
-                        Process Promotions
-                      </Button>
+                      {!session.isCurrent && (
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          startIcon={<TrendingUpIcon />}
+                          onClick={() => handleProcessPromotions(session)}
+                          disabled={!['admin', 'principal'].includes(user?.role || '')}
+                        >
+                          Process Promotions
+                        </Button>
+                      )}
                       <Button
                         size="small"
                         variant="outlined"


### PR DESCRIPTION
Hide the "Process Promotions" button when the session is current to remove it from the current session view.

---
<a href="https://cursor.com/background-agent?bcId=bc-97ebb5a8-0b65-4f14-92eb-50a490f5a03a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97ebb5a8-0b65-4f14-92eb-50a490f5a03a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

